### PR TITLE
Pull alt-text from media item's title

### DIFF
--- a/Gibe.DittoProcessors/Media/MediaService.cs
+++ b/Gibe.DittoProcessors/Media/MediaService.cs
@@ -175,8 +175,9 @@ namespace Gibe.DittoProcessors.Media
 			return new MediaImageModel
 			{
 				Url = image.Url,
+				Alt = image.Name,
 				Width = umbracoWrapper.GetPropertyValue<int>(image, "umbracoWidth"),
-				Height = umbracoWrapper.GetPropertyValue<int>(image, "umbracoHeight")
+				Height = umbracoWrapper.GetPropertyValue<int>(image, "umbracoHeight"),
 			};
 		}
 


### PR DESCRIPTION
Previously we have not taken the alt text from anywhere. Ideally this
would want to be introduced at the point of use, but there does not seem
to be a media picker which permits us to specify an alt text at that time.