### PR TITLE
Allow navigation up many parents

### DIFF
--- a/Gibe.DittoProcessors/Gibe.DittoProcessors.csproj
+++ b/Gibe.DittoProcessors/Gibe.DittoProcessors.csproj
@@ -257,6 +257,7 @@
     <Compile Include="Media\MediaService.cs" />
     <Compile Include="Media\Models\MediaFileModel.cs" />
     <Compile Include="Media\Models\MediaImageModel.cs" />
+    <Compile Include="Processors\AncestorAttribute.cs" />
     <Compile Include="Processors\DropdownMultipleAttribute.cs" />
     <Compile Include="Processors\InjectableProcessorAttribute.cs" />
     <Compile Include="Processors\MultiNodeTreePickerAttribute.cs" />

--- a/Gibe.DittoProcessors/Processors/AncestorAttribute.cs
+++ b/Gibe.DittoProcessors/Processors/AncestorAttribute.cs
@@ -35,7 +35,7 @@ namespace Gibe.DittoProcessors.Processors
 			{
 				return UmbracoWrapper().AncestorOrSelf(Context.Content, _maxDepth);
 			}
-			return UmbracoWrapper().Ancestor(Context.Content);
+			return UmbracoWrapper().AncestorOrSelf(Context.Content);
 		}
 	}
 }

--- a/Gibe.DittoProcessors/Processors/AncestorAttribute.cs
+++ b/Gibe.DittoProcessors/Processors/AncestorAttribute.cs
@@ -6,16 +6,16 @@ namespace Gibe.DittoProcessors.Processors
 {
 	public class AncestorAttribute : InjectableProcessorAttribute
 	{
-		public Func<IUmbracoWrapper> UmbracoWrapper => Inject<IUmbracoWrapper>();
+		public Func<IUmbracoWrapper> UmbracoWrapper { get; set; } = Inject<IUmbracoWrapper>();
 
-		private readonly int _maxDepth;
+		private readonly int? _maxDepth;
 		private readonly string _docTypeAlias;
 
 		public AncestorAttribute()
 		{
 		}
 
-		public AncestorAttribute(int maxDepth)
+		public AncestorAttribute(int? maxDepth)
 		{
 			_maxDepth = maxDepth;
 		}
@@ -31,9 +31,9 @@ namespace Gibe.DittoProcessors.Processors
 			{
 				return UmbracoWrapper().AncestorOrSelf(Context.Content, _docTypeAlias);
 			}
-			else if (_maxDepth != null)
+			else if (_maxDepth.HasValue)
 			{
-				return UmbracoWrapper().AncestorOrSelf(Context.Content, _maxDepth);
+				return UmbracoWrapper().AncestorOrSelf(Context.Content, _maxDepth.Value);
 			}
 			return UmbracoWrapper().AncestorOrSelf(Context.Content);
 		}

--- a/Gibe.DittoProcessors/Processors/AncestorAttribute.cs
+++ b/Gibe.DittoProcessors/Processors/AncestorAttribute.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Gibe.UmbracoWrappers;
+using Umbraco.Core.Models;
+
+namespace Gibe.DittoProcessors.Processors
+{
+	public class AncestorAttribute : InjectableProcessorAttribute
+	{
+		public Func<IUmbracoWrapper> UmbracoWrapper => Inject<IUmbracoWrapper>();
+
+		private readonly int _maxDepth;
+		private readonly string _docTypeAlias;
+
+		public AncestorAttribute()
+		{
+		}
+
+		public AncestorAttribute(int maxDepth)
+		{
+			_maxDepth = maxDepth;
+		}
+
+		public AncestorAttribute(string docTypeAlias)
+		{
+			_docTypeAlias = docTypeAlias;
+		}
+
+		public override object ProcessValue()
+		{
+			if (!string.IsNullOrEmpty(_docTypeAlias))
+			{
+				return UmbracoWrapper().AncestorOrSelf(Context.Content, _docTypeAlias);
+			}
+			else if (_maxDepth != null)
+			{
+				return UmbracoWrapper().AncestorOrSelf(Context.Content, _maxDepth);
+			}
+			return UmbracoWrapper().Ancestor(Context.Content);
+		}
+	}
+}

--- a/Gibe.DittoProcessors/Processors/InjectableProcessorAttribute.cs
+++ b/Gibe.DittoProcessors/Processors/InjectableProcessorAttribute.cs
@@ -1,10 +1,19 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Web.Mvc;
+using Umbraco.Core.Models;
 
 namespace Gibe.DittoProcessors.Processors
 {
 	public abstract class InjectableProcessorAttribute : TestableDittoProcessorAttribute
 	{
-		public Func<T> Inject<T>() => () => DependencyResolver.Current.GetService<T>();
+		protected static Func<T> Inject<T>()
+		{
+			Debug.Assert(DependencyResolver.Current == null || DependencyResolver.Current.GetService<T>() != null);
+
+			return () => DependencyResolver.Current.GetService<T>();
+		}
+
+		protected IPublishedContent Content => Value as IPublishedContent ?? Context.Content;
 	}
 }

--- a/Gibe.DittoProcessors/Processors/ParentAttribute.cs
+++ b/Gibe.DittoProcessors/Processors/ParentAttribute.cs
@@ -8,22 +8,9 @@ namespace Gibe.DittoProcessors.Processors
 {
 	public class ParentAttribute : TestableDittoProcessorAttribute
 	{
-		private readonly uint _parentDepth;
-
-		public ParentAttribute(uint parentDepth = 1)
-		{
-			_parentDepth = parentDepth;
-		}
-
 		public override object ProcessValue()
 		{
-			var content = Context.Content;
-			for (var i = 0; i < _parentDepth; i++)
-			{
-				content = content.Parent;
-			}
-
-			return content;
+			return Context.Content.Parent;
 		}
 	}
 }

--- a/Gibe.DittoProcessors/Processors/ParentAttribute.cs
+++ b/Gibe.DittoProcessors/Processors/ParentAttribute.cs
@@ -8,9 +8,22 @@ namespace Gibe.DittoProcessors.Processors
 {
 	public class ParentAttribute : TestableDittoProcessorAttribute
 	{
+		private readonly uint _parentDepth;
+
+		public ParentAttribute(uint parentDepth = 1)
+		{
+			_parentDepth = parentDepth;
+		}
+
 		public override object ProcessValue()
 		{
-			return Context.Content.Parent;
+			var content = Context.Content;
+			for (var i = 0; i < _parentDepth; i++)
+			{
+				content = content.Parent;
+			}
+
+			return content;
 		}
 	}
 }


### PR DESCRIPTION
Found this to be useful on Bristol Sport. The max depth in this refers to the depth going up the tree from the current node rather than the depth going down from the root node like AncestorAttribute.